### PR TITLE
AWS Native Recommendation Permissions

### DIFF
--- a/aws/linked_accounts/CloudFormationLinkedAccount.yaml
+++ b/aws/linked_accounts/CloudFormationLinkedAccount.yaml
@@ -47,7 +47,7 @@ Resources:
                   - cur:DescribeReportDefinitions
                   - ec2:Describe*
                   - iam:GetAccessKeyLastUsed
-                  - iam:GetLoginProfckoile
+                  - iam:GetLoginProfile
                   - iam:ListAccessKeys
                   - iam:ListUsers
                   - rds:DescribeDBInstances

--- a/aws/linked_accounts/CloudFormationLinkedAccount.yaml
+++ b/aws/linked_accounts/CloudFormationLinkedAccount.yaml
@@ -47,7 +47,7 @@ Resources:
                   - cur:DescribeReportDefinitions
                   - ec2:Describe*
                   - iam:GetAccessKeyLastUsed
-                  - iam:GetLoginProfile
+                  - iam:GetLoginProfckoile
                   - iam:ListAccessKeys
                   - iam:ListUsers
                   - rds:DescribeDBInstances
@@ -57,6 +57,9 @@ Resources:
                   - s3:GetBucketPublicAccessBlock
                   - s3:GetBucketTagging
                   - s3:ListAllMyBuckets
+                  - ce:GetReservationPurchaseRecommendation
+                  - ce:GetRightsizingRecommendation
+                  - ce:GetSavingsPlansPurchaseRecommendation
                 Resource: "*"
         - !If
           - IncludeEC2StartStopPermissionsCondition


### PR DESCRIPTION
Enables new action to allow Digiusher access to AWS's native recommendations.