### PR TITLE
feat(databricks): terraform setup for databricks

### DIFF
--- a/databricks/README.md
+++ b/databricks/README.md
@@ -1,0 +1,238 @@
+# DigiUsher Databricks Integration Setup
+
+This guide covers setting up DigiUsher's Databricks cost monitoring integration.
+The Terraform configuration creates a dedicated service principal with read-only
+access to Databricks system billing tables via Unity Catalog.
+
+---
+
+## Overview
+
+The setup creates a service principal that provides:
+
+- Access to `system.billing.usage` and `system.billing.list_prices`
+- Access to `system.compute` tables (clusters, warehouses)
+- Access to `system.access` and `system.lakeflow` tables
+- `CAN_USE` permission on the target SQL warehouse
+
+All access is read-only. Nothing is created or modified in your Databricks
+environment beyond the service principal and its grants.
+
+---
+
+## What Gets Created
+
+| Resource | Purpose |
+|---|---|
+| Service principal | Identity used by DigiUsher to query billing data |
+| OAuth client secret | Credential for the service principal |
+| Warehouse permission (`CAN_USE`) | Allows the SP to run queries |
+| Unity Catalog grants | Read access to system billing, compute, access, lakeflow schemas |
+
+---
+
+## Prerequisites
+
+- **Terraform** — version 1.3 or higher
+- **Python 3** with `databricks-sql-connector`, `databricks-sdk`, `pandas`, `pyarrow`
+- A Databricks **personal access token** with `all APIs` scope (see below)
+- **Account admin and Workspace admin** rights (needed to create service principals and assign grants)
+
+### Create a Personal Access Token
+
+This token is used once by Terraform to bootstrap the setup. It is not stored
+after `terraform apply` completes.
+
+1. Go to your workspace → top-right user icon → **Settings** → **Developer** → **Access tokens**
+2. Click **Generate new token**
+3. Set a name (e.g. `terraform-setup-digiusher`) and lifetime
+4. Under **Scope**, select **All APIs**
+5. Copy the token immediately — it won't be shown again
+
+---
+
+## Find Your Configuration Values
+
+You need four values before running Terraform:
+
+| Variable | Where to find it |
+|---|---|
+| `workspace_host` | Your workspace URL, e.g. `abc-123.cloud.databricks.com` (no `https://`) |
+| `databricks_account_id` | [accounts.cloud.databricks.com](https://accounts.cloud.databricks.com) → top-right corner |
+| `warehouse_id` | SQL warehouse → **Connection details** → last segment of the HTTP path |
+
+**Finding your values from the workspace URL:**
+
+```
+https://abcdef123456.cloud.databricks.com/?o=7474643746181715&account_id=2188c8e7-...
+                                            └─────────────── not needed  └─ account_id
+└─ workspace_host ───────────────────────┘
+```
+
+**Finding your warehouse ID:**
+
+The HTTP path in Connection details looks like `/sql/1.0/warehouses/abc123def456`.
+The `warehouse_id` is the last segment: `abc123def456`.
+
+---
+
+## Deployment
+
+### 1. Create `terraform.tfvars`
+
+```hcl
+databricks_account_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+workspace_host        = "your-workspace.cloud.databricks.com"
+warehouse_id          = "abc123def456"
+```
+
+### 2. Export your PAT
+
+```bash
+export TF_VAR_databricks_token="XXXXXXXXXXXXXXXXXXXX"
+```
+
+### 3. Initialise Terraform
+
+```bash
+terraform init
+```
+
+### 4. Review changes
+
+```bash
+terraform plan
+```
+
+Confirm it will create: 1 service principal, 1 secret, 1 warehouse permission,
+and 11 Unity Catalog grants. Nothing else.
+
+### 5. Apply
+
+```bash
+terraform apply
+```
+
+### 6. Save the credentials
+
+```bash
+terraform output client_id
+terraform output -raw client_secret
+terraform output http_path
+terraform output workspace_hostname
+```
+
+These four values are what DigiUsher needs. You can also capture them together:
+
+```bash
+echo "DATABRICKS_HOST=$(terraform output -raw workspace_hostname)"
+echo "DATABRICKS_HTTP_PATH=$(terraform output -raw http_path)"
+echo "DATABRICKS_CLIENT_ID=$(terraform output -raw client_id)"
+echo "DATABRICKS_CLIENT_SECRET=$(terraform output -raw client_secret)"
+```
+
+### 7. Verify the integration
+
+```bash
+export DATABRICKS_HOST="$(terraform output -raw workspace_hostname)"
+export DATABRICKS_HTTP_PATH="$(terraform output -raw http_path)"
+export DATABRICKS_CLIENT_ID="$(terraform output -raw client_id)"
+export DATABRICKS_CLIENT_SECRET="$(terraform output -raw client_secret)"
+
+python3 verify_exports.py
+```
+
+A successful run looks like:
+
+```
+═══════════════════════════════════════════════════════
+  Databricks Billing Integration — Verification
+═══════════════════════════════════════════════════════
+
+  Host:       your-workspace.cloud.databricks.com
+  Warehouse:  /sql/1.0/warehouses/abc123def456
+  Client ID:  xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+
+───────────────────────────────────────────────────────
+  1 / 4  —  Authentication
+───────────────────────────────────────────────────────
+   ✅  Connected to warehouse with service principal OAuth
+
+───────────────────────────────────────────────────────
+  2 / 4  —  System catalog access
+───────────────────────────────────────────────────────
+   ✅  system.billing visible
+   ✅  system.compute visible
+   ✅  system.access visible
+   ✅  system.lakeflow visible
+
+───────────────────────────────────────────────────────
+  3 / 4  —  Billing tables
+───────────────────────────────────────────────────────
+   ✅  system.billing.usage  (1,234,567 rows)
+   ✅  system.billing.list_prices  (4,321 rows)
+
+───────────────────────────────────────────────────────
+  4 / 4  —  Data availability by month
+───────────────────────────────────────────────────────
+
+   Month         Records          Units
+   ────────────  ──────────  ──────────────
+   2026-06         123,456       9,876.5
+   2026-05         234,567      18,432.1
+   ...
+
+   ✅  Data is current (latest month: 2026-06)
+
+═══════════════════════════════════════════════════════
+  ✅  All checks passed (4/4) — integration is ready.
+═══════════════════════════════════════════════════════
+```
+
+---
+
+## DigiUsher Configuration
+
+After deployment, provide DigiUsher with these four values:
+
+| Key | Source |
+|---|---|
+| `DATABRICKS_HOST` | `terraform output -raw workspace_hostname` |
+| `DATABRICKS_HTTP_PATH` | `terraform output -raw http_path` |
+| `DATABRICKS_CLIENT_ID` | `terraform output -raw client_id` |
+| `DATABRICKS_CLIENT_SECRET` | `terraform output -raw client_secret` |
+
+---
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `main.tf` | Provider, service principal, secret, warehouse permission |
+| `terraform.tfvars` | Account specific variables |
+| `verify_setup.py` | Verify connectivity and billing data availability |
+
+---
+
+## Troubleshooting
+
+**`Provided access token does not have required scopes`**
+Your PAT was created with specific scopes. Regenerate it with **All APIs** selected.
+
+**`cannot create service principal`**
+Your PAT may not have admin privileges. Confirm your user account is a
+account and workspace admin under Settings → Users.
+
+**`system.billing not visible` in verification**
+The Unity Catalog grants may not have propagated yet. Wait a few minutes and re-run
+`verify_exports.py`. If it persists, run `terraform apply` again to confirm all
+grants were applied successfully.
+
+**`No billing records found`**
+System tables can take 24–48 hours to populate on a newly enabled workspace.
+Check [docs.databricks.com](https://docs.databricks.com/aws/en/admin/system-tables/)
+to confirm system tables are enabled for your account.
+
+---
+
+Questions? Contact us at [support@digiusher.com](mailto:support@digiusher.com)

--- a/databricks/databricks_configuration.tf
+++ b/databricks/databricks_configuration.tf
@@ -1,0 +1,160 @@
+terraform {
+  required_providers {
+    databricks = {
+      source  = "databricks/databricks"
+      version = "~> 1.71"
+    }
+  }
+}
+
+# ── Variables ─────────────────────────────────────────────────────────────────
+
+variable "workspace_host" {
+  description = "Workspace hostname without https://, e.g. abc-123.cloud.databricks.com"
+  type        = string
+}
+
+variable "databricks_account_id" {
+  description = "Databricks account ID (top-right corner of accounts.cloud.databricks.com)"
+  type        = string
+}
+
+variable "warehouse_id" {
+  description = "SQL warehouse ID from Connection details HTTP path"
+  type        = string
+}
+
+variable "databricks_token" {
+  description = "Admin PAT used by Terraform to bootstrap (not needed after apply)"
+  type        = string
+  sensitive   = true
+}
+
+variable "service_principal_name" {
+  description = "Display name for the billing reader service principal"
+  type        = string
+  default     = "billing-focus-reader"
+}
+
+# ── Provider ──────────────────────────────────────────────────────────────────
+
+provider "databricks" {
+  host  = "https://${var.workspace_host}"
+  token = var.databricks_token
+}
+
+# ── Service Principal ─────────────────────────────────────────────────────────
+
+resource "databricks_service_principal" "digiusher_focus_reader" {
+  display_name = var.service_principal_name
+}
+
+resource "databricks_service_principal_secret" "digiusher_focus_reader" {
+  service_principal_id = databricks_service_principal.digiusher_focus_reader.id
+}
+
+# ── Warehouse permission ──────────────────────────────────────────────────────
+
+resource "databricks_permissions" "warehouse" {
+  sql_endpoint_id = var.warehouse_id
+
+  access_control {
+    service_principal_name = databricks_service_principal.digiusher_focus_reader.application_id
+    permission_level       = "CAN_USE"
+  }
+}
+
+# ── Unity Catalog grants ──────────────────────────────────────────────────────
+
+locals {
+  sp_id = databricks_service_principal.digiusher_focus_reader.application_id
+}
+
+resource "databricks_grant" "system_catalog" {
+  catalog    = "system"
+  principal  = local.sp_id
+  privileges = ["USE_CATALOG"]
+}
+
+resource "databricks_grant" "billing_schema" {
+  schema     = "system.billing"
+  principal  = local.sp_id
+  privileges = ["USE_SCHEMA"]
+}
+
+resource "databricks_grant" "billing_usage" {
+  table      = "system.billing.usage"
+  principal  = local.sp_id
+  privileges = ["SELECT"]
+}
+
+resource "databricks_grant" "billing_list_prices" {
+  table      = "system.billing.list_prices"
+  principal  = local.sp_id
+  privileges = ["SELECT"]
+}
+
+resource "databricks_grant" "access_schema" {
+  schema     = "system.access"
+  principal  = local.sp_id
+  privileges = ["USE_SCHEMA"]
+}
+
+resource "databricks_grant" "access_workspaces_latest" {
+  table      = "system.access.workspaces_latest"
+  principal  = local.sp_id
+  privileges = ["SELECT"]
+}
+
+resource "databricks_grant" "compute_schema" {
+  schema     = "system.compute"
+  principal  = local.sp_id
+  privileges = ["USE_SCHEMA"]
+}
+
+resource "databricks_grant" "compute_clusters" {
+  table      = "system.compute.clusters"
+  principal  = local.sp_id
+  privileges = ["SELECT"]
+}
+
+resource "databricks_grant" "compute_warehouses" {
+  table      = "system.compute.warehouses"
+  principal  = local.sp_id
+  privileges = ["SELECT"]
+}
+
+resource "databricks_grant" "lakeflow_schema" {
+  schema     = "system.lakeflow"
+  principal  = local.sp_id
+  privileges = ["USE_SCHEMA"]
+}
+
+resource "databricks_grant" "lakeflow_pipelines" {
+  table      = "system.lakeflow.pipelines"
+  principal  = local.sp_id
+  privileges = ["SELECT"]
+}
+
+# ── Outputs ───────────────────────────────────────────────────────────────────
+
+output "client_id" {
+  description = "DATABRICKS_CLIENT_ID"
+  value       = databricks_service_principal.digiusher_focus_reader.application_id
+}
+
+output "client_secret" {
+  description = "DATABRICKS_CLIENT_SECRET"
+  value       = databricks_service_principal_secret.digiusher_focus_reader.secret
+  sensitive   = true
+}
+
+output "workspace_hostname" {
+  description = "DATABRICKS_HOST"
+  value       = var.workspace_host
+}
+
+output "http_path" {
+  description = "DATABRICKS_HTTP_PATH"
+  value       = "/sql/1.0/warehouses/${var.warehouse_id}"
+}

--- a/databricks/databricks_configuration.tf
+++ b/databricks/databricks_configuration.tf
@@ -33,7 +33,7 @@ variable "databricks_token" {
 variable "service_principal_name" {
   description = "Display name for the billing reader service principal"
   type        = string
-  default     = "billing-focus-reader"
+  default     = "digisuher-focus-reader"
 }
 
 # ── Provider ──────────────────────────────────────────────────────────────────

--- a/databricks/terraform.tfvars
+++ b/databricks/terraform.tfvars
@@ -1,0 +1,3 @@
+databricks_account_id = "your-account-id"
+workspace_host        = "your-workspace.cloud.databricks.com"
+warehouse_id          = "abc123def456"

--- a/databricks/verify_exports.py
+++ b/databricks/verify_exports.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""
+Verify Databricks billing integration for DigiUsher.
+
+Checks connectivity, auth, and billing data availability using
+the service principal credentials created by Terraform.
+
+Usage:
+  # Credentials via env vars (recommended)
+  export DATABRICKS_HOST="your-workspace.cloud.databricks.com"
+  export DATABRICKS_HTTP_PATH="/sql/1.0/warehouses/your-warehouse-id"
+  export DATABRICKS_CLIENT_ID="your-sp-client-id"
+  export DATABRICKS_CLIENT_SECRET="your-sp-client-secret"
+  python3 verify_databricks.py
+
+  # Or pass credentials directly
+  python3 verify_databricks.py \
+    --host your-workspace.cloud.databricks.com \
+    --http-path /sql/1.0/warehouses/your-warehouse-id \
+    --client-id your-sp-client-id \
+    --client-secret your-sp-client-secret
+"""
+
+import argparse
+import os
+import sys
+from datetime import datetime
+
+missing = []
+try:
+    from databricks import sql as dbsql
+except ImportError:
+    missing.append("databricks-sql-connector")
+try:
+    from databricks.sdk.core import Config, oauth_service_principal
+except ImportError:
+    missing.append("databricks-sdk")
+
+if missing:
+    print(f"\n❌ Missing packages: {', '.join(missing)}")
+    print(f"   Run: pip install {' '.join(missing)}")
+    sys.exit(1)
+
+
+def ok(msg):    print(f"   ✅  {msg}")
+def fail(msg):  print(f"   ❌  {msg}")
+def info(msg):  print(f"   ℹ️   {msg}")
+def section(title): print(f"\n{'─' * 55}\n  {title}\n{'─' * 55}")
+
+
+def credential_provider(host, client_id, client_secret):
+    config = Config(
+        host=f"https://{host}",
+        client_id=client_id,
+        client_secret=client_secret,
+    )
+    return oauth_service_principal(config)
+
+
+def run_check(label, fn):
+    """Run a check function, return its result or None on failure."""
+    try:
+        result = fn()
+        return result
+    except Exception as e:
+        fail(f"{label}: {e}")
+        return None
+
+
+def check_auth(host, http_path, client_id, client_secret):
+    section("1 / 4  —  Authentication")
+    conn = None
+    try:
+        conn = dbsql.connect(
+            server_hostname=host,
+            http_path=http_path,
+            credentials_provider=lambda: credential_provider(host, client_id, client_secret),
+        )
+        ok("Connected to warehouse with service principal OAuth")
+        return conn
+    except Exception as e:
+        fail(f"Could not connect: {e}")
+        return None
+
+
+def check_system_catalog(conn):
+    section("2 / 4  —  System catalog access")
+    with conn.cursor() as cur:
+        cur.execute("SHOW SCHEMAS IN system")
+        schemas = [row[0] for row in cur.fetchall()]
+    accessible = [s for s in ["billing", "compute", "access", "lakeflow"] if s in schemas]
+    missing_s  = [s for s in ["billing", "compute", "access", "lakeflow"] if s not in schemas]
+    for s in accessible: ok(f"system.{s} visible")
+    for s in missing_s:  fail(f"system.{s} not visible — check Unity Catalog grants")
+    return len(missing_s) == 0
+
+
+def check_billing_tables(conn):
+    section("3 / 4  —  Billing tables")
+    tables = {
+        "system.billing.usage":       "SELECT COUNT(*) FROM system.billing.usage",
+        "system.billing.list_prices": "SELECT COUNT(*) FROM system.billing.list_prices",
+    }
+    all_ok = True
+    for table, query in tables.items():
+        with conn.cursor() as cur:
+            cur.execute(query)
+            count = cur.fetchone()[0]
+        ok(f"{table}  ({count:,} rows)")
+    return all_ok
+
+
+def check_data_freshness(conn):
+    section("4 / 4  —  Data availability by month")
+    query = """
+        SELECT
+            date_trunc('month', usage_date) AS month,
+            COUNT(*)                        AS records,
+            SUM(usage_quantity)             AS total_units
+        FROM system.billing.usage
+        GROUP BY 1
+        ORDER BY 1 DESC
+        LIMIT 13
+    """
+    with conn.cursor() as cur:
+        cur.execute(query)
+        rows = cur.fetchall()
+
+    if not rows:
+        fail("No billing records found")
+        return False
+
+    print(f"\n   {'Month':<12}  {'Records':>10}  {'Units':>14}")
+    print(f"   {'─'*12}  {'─'*10}  {'─'*14}")
+    for row in rows:
+        month  = str(row[0])[:7]
+        recs   = f"{row[1]:,}"
+        units  = f"{float(row[2]):,.1f}" if row[2] else "—"
+        print(f"   {month:<12}  {recs:>10}  {units:>14}")
+
+    latest = str(rows[0][0])[:7]
+    current_month = datetime.today().strftime("%Y-%m")
+    if latest >= current_month:
+        ok(f"Data is current (latest month: {latest})")
+    else:
+        info(f"Latest month in warehouse: {latest} — may lag by a few days")
+    return True
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Verify Databricks billing integration",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Credentials can be passed as flags or set as environment variables:
+  DATABRICKS_HOST, DATABRICKS_HTTP_PATH,
+  DATABRICKS_CLIENT_ID, DATABRICKS_CLIENT_SECRET
+        """
+    )
+    parser.add_argument("--host",          default=os.environ.get("DATABRICKS_HOST"))
+    parser.add_argument("--http-path",     default=os.environ.get("DATABRICKS_HTTP_PATH"))
+    parser.add_argument("--client-id",     default=os.environ.get("DATABRICKS_CLIENT_ID"))
+    parser.add_argument("--client-secret", default=os.environ.get("DATABRICKS_CLIENT_SECRET"))
+    args = parser.parse_args()
+
+    missing_args = [k for k, v in {
+        "--host":          args.host,
+        "--http-path":     args.http_path,
+        "--client-id":     args.client_id,
+        "--client-secret": args.client_secret,
+    }.items() if not v]
+
+    if missing_args:
+        print(f"\n❌ Missing credentials: {', '.join(missing_args)}")
+        print("   Set them as env vars or pass as flags. Run with --help for details.")
+        sys.exit(1)
+
+    print("\n" + "═" * 55)
+    print("  Databricks Billing Integration — Verification")
+    print("═" * 55)
+    print(f"\n  Host:       {args.host}")
+    print(f"  Warehouse:  {args.http_path}")
+    print(f"  Client ID:  {args.client_id}")
+
+    passed = 0
+    total  = 4
+
+    conn = check_auth(args.host, args.http_path, args.client_id, args.client_secret)
+    if conn is None:
+        print(f"\n{'═' * 55}")
+        print("  ❌  Auth failed — stopping. Check credentials and warehouse ID.")
+        print("═" * 55 + "\n")
+        sys.exit(1)
+    passed += 1
+
+    try:
+        if check_system_catalog(conn):  passed += 1
+        if check_billing_tables(conn):  passed += 1
+        if check_data_freshness(conn):  passed += 1
+    finally:
+        conn.close()
+
+    print(f"\n{'═' * 55}")
+    if passed == total:
+        print(f"  ✅  All checks passed ({passed}/{total}) — integration is ready.")
+    else:
+        print(f"  ⚠️   {passed}/{total} checks passed — review failures above.")
+    print("═" * 55 + "\n")
+    sys.exit(0 if passed == total else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/databricks/verify_exports.py
+++ b/databricks/verify_exports.py
@@ -11,10 +11,10 @@ Usage:
   export DATABRICKS_HTTP_PATH="/sql/1.0/warehouses/your-warehouse-id"
   export DATABRICKS_CLIENT_ID="your-sp-client-id"
   export DATABRICKS_CLIENT_SECRET="your-sp-client-secret"
-  python3 verify_databricks.py
+  python3 verify_exports.py
 
   # Or pass credentials directly
-  python3 verify_databricks.py \
+  python3 verify_exports.py \
     --host your-workspace.cloud.databricks.com \
     --http-path /sql/1.0/warehouses/your-warehouse-id \
     --client-id your-sp-client-id \
@@ -42,10 +42,20 @@ if missing:
     sys.exit(1)
 
 
-def ok(msg):    print(f"   ✅  {msg}")
-def fail(msg):  print(f"   ❌  {msg}")
-def info(msg):  print(f"   ℹ️   {msg}")
-def section(title): print(f"\n{'─' * 55}\n  {title}\n{'─' * 55}")
+def ok(msg):
+    print(f"   ✅  {msg}")
+
+
+def fail(msg):
+    print(f"   ❌  {msg}")
+
+
+def info(msg):
+    print(f"   ℹ️   {msg}")
+
+
+def section(title):
+    print(f"\n{'─' * 55}\n  {title}\n{'─' * 55}")
 
 
 def credential_provider(host, client_id, client_secret):
@@ -74,7 +84,9 @@ def check_auth(host, http_path, client_id, client_secret):
         conn = dbsql.connect(
             server_hostname=host,
             http_path=http_path,
-            credentials_provider=lambda: credential_provider(host, client_id, client_secret),
+            credentials_provider=lambda: credential_provider(
+                host, client_id, client_secret
+            ),
         )
         ok("Connected to warehouse with service principal OAuth")
         return conn
@@ -88,25 +100,35 @@ def check_system_catalog(conn):
     with conn.cursor() as cur:
         cur.execute("SHOW SCHEMAS IN system")
         schemas = [row[0] for row in cur.fetchall()]
-    accessible = [s for s in ["billing", "compute", "access", "lakeflow"] if s in schemas]
-    missing_s  = [s for s in ["billing", "compute", "access", "lakeflow"] if s not in schemas]
-    for s in accessible: ok(f"system.{s} visible")
-    for s in missing_s:  fail(f"system.{s} not visible — check Unity Catalog grants")
+    accessible = [
+        s for s in ["billing", "compute", "access", "lakeflow"] if s in schemas
+    ]
+    missing_s = [
+        s for s in ["billing", "compute", "access", "lakeflow"] if s not in schemas
+    ]
+    for s in accessible:
+        ok(f"system.{s} visible")
+    for s in missing_s:
+        fail(f"system.{s} not visible — check Unity Catalog grants")
     return len(missing_s) == 0
 
 
 def check_billing_tables(conn):
     section("3 / 4  —  Billing tables")
     tables = {
-        "system.billing.usage":       "SELECT COUNT(*) FROM system.billing.usage",
+        "system.billing.usage": "SELECT COUNT(*) FROM system.billing.usage",
         "system.billing.list_prices": "SELECT COUNT(*) FROM system.billing.list_prices",
     }
     all_ok = True
     for table, query in tables.items():
-        with conn.cursor() as cur:
-            cur.execute(query)
-            count = cur.fetchone()[0]
-        ok(f"{table}  ({count:,} rows)")
+        try:
+            with conn.cursor() as cur:
+                cur.execute(query)
+                count = cur.fetchone()[0]
+            ok(f"{table}  ({count:,} rows)")
+        except Exception as e:
+            fail(f"{table} — {e}")
+            all_ok = False
     return all_ok
 
 
@@ -131,11 +153,11 @@ def check_data_freshness(conn):
         return False
 
     print(f"\n   {'Month':<12}  {'Records':>10}  {'Units':>14}")
-    print(f"   {'─'*12}  {'─'*10}  {'─'*14}")
+    print(f"   {'─' * 12}  {'─' * 10}  {'─' * 14}")
     for row in rows:
-        month  = str(row[0])[:7]
-        recs   = f"{row[1]:,}"
-        units  = f"{float(row[2]):,.1f}" if row[2] else "—"
+        month = str(row[0])[:7]
+        recs = f"{row[1]:,}"
+        units = f"{float(row[2]):,.1f}" if row[2] else "—"
         print(f"   {month:<12}  {recs:>10}  {units:>14}")
 
     latest = str(rows[0][0])[:7]
@@ -155,20 +177,26 @@ def main():
 Credentials can be passed as flags or set as environment variables:
   DATABRICKS_HOST, DATABRICKS_HTTP_PATH,
   DATABRICKS_CLIENT_ID, DATABRICKS_CLIENT_SECRET
-        """
+        """,
     )
-    parser.add_argument("--host",          default=os.environ.get("DATABRICKS_HOST"))
-    parser.add_argument("--http-path",     default=os.environ.get("DATABRICKS_HTTP_PATH"))
-    parser.add_argument("--client-id",     default=os.environ.get("DATABRICKS_CLIENT_ID"))
-    parser.add_argument("--client-secret", default=os.environ.get("DATABRICKS_CLIENT_SECRET"))
+    parser.add_argument("--host", default=os.environ.get("DATABRICKS_HOST"))
+    parser.add_argument("--http-path", default=os.environ.get("DATABRICKS_HTTP_PATH"))
+    parser.add_argument("--client-id", default=os.environ.get("DATABRICKS_CLIENT_ID"))
+    parser.add_argument(
+        "--client-secret", default=os.environ.get("DATABRICKS_CLIENT_SECRET")
+    )
     args = parser.parse_args()
 
-    missing_args = [k for k, v in {
-        "--host":          args.host,
-        "--http-path":     args.http_path,
-        "--client-id":     args.client_id,
-        "--client-secret": args.client_secret,
-    }.items() if not v]
+    missing_args = [
+        k
+        for k, v in {
+            "--host": args.host,
+            "--http-path": args.http_path,
+            "--client-id": args.client_id,
+            "--client-secret": args.client_secret,
+        }.items()
+        if not v
+    ]
 
     if missing_args:
         print(f"\n❌ Missing credentials: {', '.join(missing_args)}")
@@ -183,7 +211,7 @@ Credentials can be passed as flags or set as environment variables:
     print(f"  Client ID:  {args.client_id}")
 
     passed = 0
-    total  = 4
+    total = 4
 
     conn = check_auth(args.host, args.http_path, args.client_id, args.client_secret)
     if conn is None:
@@ -194,9 +222,12 @@ Credentials can be passed as flags or set as environment variables:
     passed += 1
 
     try:
-        if check_system_catalog(conn):  passed += 1
-        if check_billing_tables(conn):  passed += 1
-        if check_data_freshness(conn):  passed += 1
+        if run_check("System catalog access", lambda: check_system_catalog(conn)):
+            passed += 1
+        if run_check("Billing tables", lambda: check_billing_tables(conn)):
+            passed += 1
+        if run_check("Data availability", lambda: check_data_freshness(conn)):
+            passed += 1
     finally:
         conn.close()
 


### PR DESCRIPTION
Add a terraform script along with steps to execute it to automate setup of databricks connector (create a service principal, attach to workspace, add grants, destroy them when the setup process is done).

Requires a user account with both workspace admin and account admin permissions to run. Three basic details and one access token (PAT) is required to run the script to generate values that can be put into the digiusher connector.